### PR TITLE
Timecourse bugfix

### DIFF
--- a/mspypeline/core/MSPPlots/BasePlotter.py
+++ b/mspypeline/core/MSPPlots/BasePlotter.py
@@ -1498,6 +1498,7 @@ class BasePlotter:
         # import the r_timecourse_plot.R script
         ro.r(f'''source("{r_script_path}")''')
         # get plot settings from configs
+        match_time_norm = self.configs["plot_r_timecourse_settings"].get("matching_time_normalization")
         savedir = self.file_dir_timecourse.replace('\\', '/')
         ctrl_condition = self.configs["plot_r_timecourse_settings"].get("sample_to_normalize")
         print(f"Ctrl condition {ctrl_condition}")


### PR DESCRIPTION
For time course plotting: 
* Fixed bug related to match_time_norm not found
* Skips a genelist if the genes are not present in the data (instead of causing an error as before) and informs user
* Labels for conditions are reformatted ("_" are removed) prior to exporting figures

